### PR TITLE
Fix wraparound and negative bucket count bugs in TimeWindow.WindowAverage

### DIFF
--- a/metrics/metrics_window.go
+++ b/metrics/metrics_window.go
@@ -218,12 +218,14 @@ func (t *TimeWindow) WindowAverage(now time.Time) float64 {
 		stIdx := t.timeToIndex(t.lastWrite)
 		eIdx := t.timeToIndex(now)
 		ret := t.windowTotal
-		for i := stIdx + 1; i <= eIdx; i++ {
-			ret -= t.buckets[i%len(t.buckets)]
+		bucketsToRemove := min(eIdx-stIdx, len(t.buckets))
+		for i := 1; i <= bucketsToRemove; i++ {
+			idx := (stIdx + i) % len(t.buckets)
+			ret -= t.buckets[idx]
 		}
 		numB := math.Min(
 			float64(t.lastWrite.Sub(t.firstWrite)/t.granularity)+1, // +1 since the times are inclusive.
-			float64(len(t.buckets)-(eIdx-stIdx)))
+			float64(len(t.buckets)-bucketsToRemove))
 		return roundToNDigits(precision, ret/numB)
 	default: // Nothing for more than a window time, just 0.
 		return 0.


### PR DESCRIPTION
Fixed two critical bugs in the WindowAverage calculation:

1. Wraparound bug: When the time gap between lastWrite and now exceeded the bucket array size, the modulo operation caused buckets to be subtracted multiple times. Now capped to bucketsToRemove = min(eIdx-stIdx, len(t.buckets)).

2. Negative bucket count: The calculation len(t.buckets)-(eIdx-stIdx) could become negative when eIdx-stIdx > len(t.buckets). Now uses the same capped bucketsToRemove value to prevent negative results.

Example: With 30 buckets (60s window / 2s granularity), if the gap was 65 seconds, the old code would:
- Iterate 32+ times, incorrectly subtracting some buckets twice
- Calculate numB with a negative value (30-32 = -2)

These bugs could cause:
- Incorrect averages (too low or negative) when gaps approach window size
- Division by zero or negative denominators
- Unpredictable behavior in long-running systems

Fixes data integrity issues in metrics calculation.